### PR TITLE
added AWS KMS encryption for files stored on s3

### DIFF
--- a/AWS.md
+++ b/AWS.md
@@ -15,6 +15,11 @@ and "letsencrypt-certs.MYWEBSITE.com" to store files, and gives access to two ho
     "Version": "2012-10-17",
     "Statement": [
         {
+		"Effect": "Allow",
+		"Action": [ "kms:Decrypt", "kms:Encrypt" ],
+		"Resource": "arn:aws:kms:REGION:999999999999:key/01234567-890a-bcde-f012-3456789abcde"
+        },
+        {
             "Effect": "Allow",
             "Action": [
                 "s3:ListBucket"
@@ -58,6 +63,9 @@ and "letsencrypt-certs.MYWEBSITE.com" to store files, and gives access to two ho
     ]
 }
 ```
+
+## AWS KMS
+The role used by Lambda will also need to be added to Key Users on the KMS key referenced in its IAM Policy.
 
 ## Lambda Execution
 The Lambda function needs to run periodically as a scheduled function, preferably

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ your environment:
 | :--------------------- |:--------------|
 | `acme-directory-url`            | Change to production url - https://acme-v01.api.letsencrypt.org if ready for real certificate.  |
 | `acme-account-email`            | Email of user requesting certificate.  |
+| `kms-key`                       | A fully qualified AWS KMS key ARN that will be used to encrypt the files stored in the buckets. |
 | `s3-account-bucket`            | An S3 bucket to place account keys/config data into. You will need to create this bucket and assign the [IAM role](AWS.md) to read/write.  |
 | `s3-cert-bucket`            | An S3 bucket to place domain certificate data into. You will need to create this bucket and assign the [IAM role](AWS.md) to read/write.  |
 | `s3-folder`            | A folder within the above buckets to place the files under, in case there are other contents of these buckets.  |

--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,5 @@
 {
+  "kms-key": "<your-aws-kms-key>",
   "s3-account-bucket": "<your-s3-account-config-bucket>",
   "s3-cert-bucket": "<your-s3-ssl-cert-bucket>",
   "s3-folder": "<folder-under-bucket>",

--- a/src/acme/certify/createCertificate.js
+++ b/src/acme/certify/createCertificate.js
@@ -6,6 +6,7 @@ const saveFile = require('../../aws/s3/saveFile')
 
 const saveCertificate = (data) =>
   saveFile(
+    config['kms-key'],
     config['s3-cert-bucket'],
     config['s3-folder'],
     `${data.key}.json`,

--- a/src/acme/register/createAccount.js
+++ b/src/acme/register/createAccount.js
@@ -10,6 +10,7 @@ const saveAccount = (data) => {
     'agreement': data.agreement
   }
   return saveFile(
+    config['kms-key'],
     config['s3-account-bucket'],
     config['s3-folder'],
     config['acme-account-file'],

--- a/src/aws/s3/saveFile.js
+++ b/src/aws/s3/saveFile.js
@@ -1,9 +1,11 @@
 const getS3 = require('../sdk/getS3')
 
-const saveFile = (bucket, siteId, fileName, fileData, options) =>
+const saveFile = (kmskey, bucket, siteId, fileName, fileData, options) =>
   getS3().putObject(Object.assign({
     Bucket: bucket,
     Key: `${siteId}/${fileName}`,
+    ServerSideEncryption: "aws:kms",
+    SSEKMSKeyId: ${kmskey},
     Body: new Buffer(fileData)
   }, options)).promise()
   .catch((e) => {


### PR DESCRIPTION
Since certs/private keys are being stored on S3, I thought it might be a good idea to add AWS KMS to the mix. This commit allows the function to store/retrieve the cert/account files and encrypt at rest using the specified KMS key.