### PR TITLE
Support storing cert-info in S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ your environment:
 | `s3-cert-bucket`            | An S3 bucket to place domain certificate data into. You will need to create this bucket and assign the [IAM role](AWS.md) to read/write.  |
 | `s3-folder`            | A folder within the above buckets to place the files under, in case there are other contents of these buckets.  |
 | `certificate-info`            | Object containing [certificate information mapping](https://github.com/ocelotconsulting/node-letsencrypt-lambda#certificate-info-field-of-configuration-file) certificate names to domains.  |
+| `certificate-info-file` | As an alternative to `certificate-info`, you can specify here the name of a JSON file containing the certificate information mapping. This will be looked for in the `s3-folder` folder of the `s3-account-bucket`. |
 
 ## Execution
 Follow these steps to get started:

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 const generateCertificate = require('./src/acme/generateCertificate')
 const isExpired = require('./src/util/isExpired')
 const config = require('./config/default.json')
+const readFile = require('./src/aws/s3/readFile')
 
 const single = (key, domains) =>
   isExpired(key)
@@ -24,8 +25,23 @@ const certificates = (certDefinitions) =>
     single(certKey, certDefinitions[certKey])
   )
 
+const certDefinitions = () => {
+  if (config['certificate-info']) {
+    return Promise.accept(config['certificate-info'])
+  } else if (config['certificate-info-file']) {
+    return readFile(config['s3-account-bucket'],
+      config['s3-folder'],
+      config['certificate-info-file']
+    ).then((data) => JSON.parse(data.Body.toString()))
+  } else {
+    return Promise.reject('need to specify either certificate-info or certificate-info-file in config')
+  }
+}
+
 const updateCertificates = (options, context) =>
-  Promise.all(certificates(config['certificate-info']))
+  certDefinitions()
+  .then((definitions) => Promise.all(certificates(definitions)))
   .then((msgs) => context.succeed(msgs))
+  .catch((e) => context.fail(e))
 
 module.exports = { handler: updateCertificates }

--- a/bin/local.js
+++ b/bin/local.js
@@ -4,6 +4,10 @@ const testContext = {
   succeed: (data) => {
     console.log(data)
     process.exit(0)
+  },
+  fail: (data) => {
+    console.error(data)
+    process.exit(1)
   }
 }
 


### PR DESCRIPTION
For some use cases, it may be inconvenient to redeploy the lambda every time the `certificate-info` changes. This allows the option of storing the certificate info in a JSON file in the `s3-account-bucket`, while still supporting storing the info directly in the config for cases where that is simpler.