### PR TITLE
Add support for zone id in domain name

### DIFF
--- a/src/aws/route53/getHostedZoneId.js
+++ b/src/aws/route53/getHostedZoneId.js
@@ -4,6 +4,10 @@ const getDomainZone = (domain, zones) =>
   zones.HostedZones.find((zone) => zone.Name === `${domain}.`)
 
 const getHostedZoneId = (domain) => {
+  if (typeof domain == 'object' && domain.zoneId) {
+    return domain.zoneId
+  }
+
   const domainName = (typeof domain === 'string') ? domain : domain.name
   const zoneLevels = (typeof domain === 'object' && domain.zoneLevels)
     ? domain.zoneLevels


### PR DESCRIPTION
Add support for explicitly specifying the AWS Zone ID in the hash containing a domain name.